### PR TITLE
Save confidence values when adding new fields

### DIFF
--- a/complex_fields/models.py
+++ b/complex_fields/models.py
@@ -314,6 +314,7 @@ class ComplexFieldContainer(object):
 
         if self.sourced:
             c_field.confidence = sources['confidence']
+            c_field.save()
             for source in sources.get('sources', []):
                 c_field.sources.add(source)
 


### PR DESCRIPTION
This PR makes sure we save models when adding `confidence` values. Previous iterations of the code saved `value` and `source` attributes, but not `confidence`.